### PR TITLE
chore: update CODEOWNERS for dependency files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @kinde-oss/giants-kinde
+pyproject.toml @kinde-oss/sdk-engineers
+**/pyproject.toml @kinde-oss/sdk-engineers
+requirements.txt @kinde-oss/sdk-engineers
+**/requirements.txt @kinde-oss/sdk-engineers


### PR DESCRIPTION
Automated update to CODEOWNERS so that @kinde-oss/sdk-engineers own dependency definition files and can approve dependency PRs.